### PR TITLE
Advice: the 'Empty View' should stay in center of list instead of its parent container

### DIFF
--- a/EmptyLayout/src/com/kanak/emptylayout/EmptyLayout.java
+++ b/EmptyLayout/src/com/kanak/emptylayout/EmptyLayout.java
@@ -448,23 +448,32 @@ public class EmptyLayout {
 		setDefaultValues();
 		refreshMessages();
 
-		// insert views in the root view
-		if (!mViewsAdded) {
-			RelativeLayout.LayoutParams lp = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-			lp.addRule(RelativeLayout.CENTER_HORIZONTAL);
-			lp.addRule(RelativeLayout.CENTER_VERTICAL);
-			RelativeLayout rl = new RelativeLayout(mContext);
-			rl.setLayoutParams(lp);
-			if (mEmptyView!=null) rl.addView(mEmptyView);
-			if (mLoadingView!=null) rl.addView(mLoadingView);
-			if (mErrorView!=null) rl.addView(mErrorView);
-			mViewsAdded = true;			
-
-			ViewGroup parent = (ViewGroup) mListView.getParent();
-			parent.addView(rl);
-			mListView.setEmptyView(rl);
-		}
-		
+        // insert views in the root view
+        if (!mViewsAdded) {
+            RelativeLayout.LayoutParams lp = new LayoutParams(mListView.getWidth(), mListView.getHeight());
+            lp.topMargin = mListView.getTop();
+            lp.leftMargin = mListView.getLeft();
+            RelativeLayout rl = new RelativeLayout(mContext);
+            rl.setLayoutParams(lp);
+            if (mEmptyView != null) {
+                rl.addView(mEmptyView);
+                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mEmptyView.getLayoutParams();
+                layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT);
+                mEmptyView.setLayoutParams(layoutParams);
+            }
+            if (mLoadingView != null) {
+                rl.addView(mLoadingView);
+                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mLoadingView.getLayoutParams();
+                layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT);
+                mLoadingView.setLayoutParams(layoutParams);
+            }
+            if (mErrorView != null) {
+                rl.addView(mErrorView);
+                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mErrorView.getLayoutParams();
+                layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT);
+                mErrorView.setLayoutParams(layoutParams);
+            }
+        }
 		
 		// change empty type
 		if (mListView!=null) {


### PR DESCRIPTION
hello, I found a problem while learning your code. see the usage below:
![image](https://cloud.githubusercontent.com/assets/9317897/7157527/1a3742cc-e3a3-11e4-9520-316147e2bdfd.png)
then, you add "Empty View" into the parent of `mListView` (see EmptyLayout.java:463)
You view looks like this:
![image](https://cloud.githubusercontent.com/assets/9317897/7157530/237af766-e3a3-11e4-95e1-1e1679770fd9.png)
Obviously, I want the picture in center of list view instead of its parent.
![image](https://cloud.githubusercontent.com/assets/9317897/7157698/8b04930a-e3a4-11e4-87b9-10e13662b61e.png)
---------------------------------
Now I make a little change at `EmptyLayout.java:changeEmptyType()`, you can easily understand.

    ~~~
        // insert views in the root view
        if (!mViewsAdded) {
            RelativeLayout.LayoutParams lp = new LayoutParams(mListView.getWidth(), mListView.getHeight());
            lp.topMargin = mListView.getTop();
            lp.leftMargin = mListView.getLeft();
            RelativeLayout rl = new RelativeLayout(mContext);
            rl.setLayoutParams(lp);
            if (mEmptyView!=null) {
                rl.addView(mEmptyView);
                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mEmptyView.getLayoutParams();
                layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT);
                mEmptyView.setLayoutParams(layoutParams);
            }
            if (mLoadingView!=null) {
                rl.addView(mLoadingView);
                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mLoadingView.getLayoutParams();
                layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT);
                mLoadingView.setLayoutParams(layoutParams);
            }
            if (mErrorView!=null) {
                rl.addView(mErrorView);
                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mErrorView.getLayoutParams();
                layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT);
                mErrorView.setLayoutParams(layoutParams);
            }
            mViewsAdded = true;

            ViewGroup parent = (ViewGroup) mListView.getParent();
            parent.addView(rl);
            mListView.setEmptyView(rl);
        }
    ~~~

Thanks for your good code.